### PR TITLE
feat: refresh approval popup visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 - `approval-requested` now defaults to popup UX (`popup`) with visible choice buttons instead of notification action menus.
 - Popup buttons are now dynamic: if payload has two choices (for example `yes/no`), only two buttons are shown.
+- Refined popup visual style with semantic action button colors, subtle entrance/exit animation, and timeout progress bar.
 - Added `codex-notify action submit --text ...` so unknown option labels can still be sent as typed input.
 - Added `single` as an alias of `popup` for backward compatibility.
 - Added `CODEX_NOTIFY_ENABLE_POPUP_APPROVAL_ACTIONS` (with legacy alias `CODEX_NOTIFY_ENABLE_NATIVE_APPROVAL_ACTIONS`) and `CODEX_NOTIFY_APPROVAL_TIMEOUT_SECONDS`.

--- a/internal/swift/approval_action_notifier.swift
+++ b/internal/swift/approval_action_notifier.swift
@@ -9,6 +9,7 @@ struct Choice {
 struct Config {
     let title: String
     let message: String
+    let identifier: String
     let timeoutSeconds: Int
     let choices: [Choice]
 }
@@ -37,6 +38,7 @@ private func parseArgs(_ args: [String]) -> Config {
 
     let title = value("--title") ?? "Codex: Approval Requested"
     let message = value("--message") ?? "承認待ちです。"
+    let identifier = value("--identifier") ?? ""
 
     let timeoutRaw = value("--timeout-seconds") ?? "45"
     let timeoutParsed = Int(timeoutRaw) ?? 45
@@ -69,6 +71,7 @@ private func parseArgs(_ args: [String]) -> Config {
     return Config(
         title: title,
         message: message,
+        identifier: identifier,
         timeoutSeconds: timeoutSeconds,
         choices: choices
     )
@@ -96,27 +99,241 @@ private func runShell(_ command: String) {
     }
 }
 
+enum ChoiceIntent {
+    case primary
+    case destructive
+    case neutral
+    case secondary
+}
+
+private func choiceIntent(for label: String, index: Int, total: Int) -> ChoiceIntent {
+    var normalized = label.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    normalized = normalized.replacingOccurrences(of: " ", with: "")
+    normalized = normalized.replacingOccurrences(of: "-", with: "")
+    normalized = normalized.replacingOccurrences(of: "_", with: "")
+
+    switch normalized {
+    case "open", "focus", "show", "view":
+        return .neutral
+    case "approve", "approved", "allow", "yes", "y", "ok":
+        return .primary
+    case "reject", "denied", "deny", "no", "n", "cancel":
+        return .destructive
+    default:
+        break
+    }
+
+    if total == 2 {
+        return index == 0 ? .primary : .destructive
+    }
+    if index == 0 {
+        return .primary
+    }
+    return .secondary
+}
+
+private func shortenedIdentifier(_ raw: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.count <= 22 {
+        return trimmed
+    }
+
+    let head = trimmed.prefix(10)
+    let tail = trimmed.suffix(8)
+    return "\(head)...\(tail)"
+}
+
+private func chunkChoices(_ choices: [Choice], columns: Int) -> [[Choice]] {
+    guard columns > 0 else {
+        return [choices]
+    }
+
+    var rows: [[Choice]] = []
+    var index = 0
+    while index < choices.count {
+        let end = min(index + columns, choices.count)
+        rows.append(Array(choices[index..<end]))
+        index = end
+    }
+    return rows
+}
+
+private func columnsPerRow(choiceCount: Int) -> Int {
+    switch choiceCount {
+    case ..<1:
+        return 1
+    case 1...3:
+        return choiceCount
+    case 4...6:
+        return 3
+    default:
+        return 4
+    }
+}
+
+private struct ButtonPalette {
+    let base: NSColor
+    let hover: NSColor
+    let border: NSColor
+    let text: NSColor
+}
+
+private func buttonPalette(for intent: ChoiceIntent) -> ButtonPalette {
+    switch intent {
+    case .primary:
+        return ButtonPalette(
+            base: NSColor.systemBlue.withAlphaComponent(0.85),
+            hover: NSColor.systemBlue.withAlphaComponent(0.98),
+            border: NSColor.systemBlue.withAlphaComponent(1.0),
+            text: NSColor.white
+        )
+    case .destructive:
+        return ButtonPalette(
+            base: NSColor.systemRed.withAlphaComponent(0.83),
+            hover: NSColor.systemRed.withAlphaComponent(0.96),
+            border: NSColor.systemRed.withAlphaComponent(1.0),
+            text: NSColor.white
+        )
+    case .neutral:
+        return ButtonPalette(
+            base: NSColor.white.withAlphaComponent(0.16),
+            hover: NSColor.white.withAlphaComponent(0.24),
+            border: NSColor.white.withAlphaComponent(0.32),
+            text: NSColor.labelColor
+        )
+    case .secondary:
+        return ButtonPalette(
+            base: NSColor.controlAccentColor.withAlphaComponent(0.35),
+            hover: NSColor.controlAccentColor.withAlphaComponent(0.55),
+            border: NSColor.controlAccentColor.withAlphaComponent(0.7),
+            text: NSColor.labelColor
+        )
+    }
+}
+
+final class StyledActionButton: NSButton {
+    private let palette: ButtonPalette
+    private var tracking: NSTrackingArea?
+
+    init(title: String, intent: ChoiceIntent, index: Int, target: AnyObject?, action: Selector?) {
+        self.palette = buttonPalette(for: intent)
+        super.init(frame: .zero)
+
+        self.target = target
+        self.action = action
+        self.title = title
+        self.tag = index
+        self.isBordered = false
+        self.bezelStyle = .regularSquare
+        self.setButtonType(.momentaryPushIn)
+        self.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        self.focusRingType = .none
+        self.wantsLayer = true
+        self.layer?.cornerRadius = 10
+        self.layer?.borderWidth = 1
+        self.layer?.masksToBounds = true
+
+        if index == 0 {
+            self.keyEquivalent = "\r"
+            self.keyEquivalentModifierMask = []
+        } else if index < 9 {
+            self.keyEquivalent = String(index + 1)
+            self.keyEquivalentModifierMask = []
+        }
+
+        self.attributedTitle = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 13, weight: .semibold),
+                .foregroundColor: palette.text
+            ]
+        )
+
+        apply(baseColor: palette.base)
+        self.layer?.borderColor = palette.border.cgColor
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        if let tracking {
+            removeTrackingArea(tracking)
+        }
+
+        let options: NSTrackingArea.Options = [.activeInKeyWindow, .mouseEnteredAndExited, .inVisibleRect]
+        let tracking = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+        addTrackingArea(tracking)
+        self.tracking = tracking
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        apply(baseColor: palette.hover)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        apply(baseColor: palette.base)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        apply(baseColor: palette.hover.blended(withFraction: 0.2, of: NSColor.black) ?? palette.hover)
+        super.mouseDown(with: event)
+        apply(baseColor: palette.base)
+    }
+
+    private func apply(baseColor: NSColor) {
+        layer?.backgroundColor = baseColor.cgColor
+    }
+}
+
+final class PopupPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
 final class PopupController: NSObject {
     private let config: Config
-    private var panel: NSPanel?
+    private var panel: PopupPanel?
     private var timeoutTimer: Timer?
+    private var progressTimer: Timer?
+    private var progressFill: NSView?
+    private var progressTrackWidth: CGFloat = 0
+    private var openedAt = Date()
+    private var isClosing = false
 
     init(config: Config) {
         self.config = config
     }
 
     func show() {
-        let width: CGFloat = max(360, min(720, CGFloat(220 + config.message.count * 2)))
-        let messageHeight = textHeight(config.message, width: width - 36)
-        let panelHeight: CGFloat = 70 + messageHeight + 48
+        let columns = columnsPerRow(choiceCount: config.choices.count)
+        let widthByMessage = max(390, min(720, CGFloat(config.message.count) * 3.0 + 280))
+        let interButtonSpacing = max(columns - 1, 0)
+        let widthByColumnsValue = columns * 128 + interButtonSpacing * 8 + 36
+        let widthByColumns = CGFloat(widthByColumnsValue)
+        let width = max(widthByMessage, widthByColumns)
+
+        let messageHeight = min(130, textHeight(config.message, width: width - 48))
+        let rows = chunkChoices(config.choices, columns: columns)
+        let rowHeight: CGFloat = 36
+        let rowSpacing: CGFloat = 8
+        let buttonsHeight = CGFloat(rows.count) * rowHeight + CGFloat(max(0, rows.count - 1)) * rowSpacing
+        let panelHeight: CGFloat = 104 + messageHeight + buttonsHeight
 
         let visible = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1200, height: 800)
         let x = visible.maxX - width - 18
         let y = visible.minY + 22
-        let frame = NSRect(x: x, y: y, width: width, height: panelHeight)
+        let finalFrame = NSRect(x: x, y: y, width: width, height: panelHeight)
+        let startFrame = NSRect(x: x, y: y - 14, width: width, height: panelHeight)
 
-        let panel = NSPanel(
-            contentRect: frame,
+        let panel = PopupPanel(
+            contentRect: startFrame,
             styleMask: [.nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -130,59 +347,172 @@ final class PopupController: NSObject {
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
-        let root = NSVisualEffectView(frame: NSRect(origin: .zero, size: frame.size))
+        let root = NSVisualEffectView(frame: NSRect(origin: .zero, size: finalFrame.size))
         root.autoresizingMask = [.width, .height]
         root.blendingMode = .withinWindow
         root.state = .active
-        root.material = .hudWindow
+        root.material = .popover
         root.wantsLayer = true
-        root.layer?.cornerRadius = 12
+        root.layer?.cornerRadius = 16
+        root.layer?.borderWidth = 1
+        root.layer?.borderColor = NSColor.white.withAlphaComponent(0.18).cgColor
         root.layer?.masksToBounds = true
         panel.contentView = root
 
+        let tint = NSView(frame: root.bounds)
+        tint.autoresizingMask = [.width, .height]
+        tint.wantsLayer = true
+        tint.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.08).cgColor
+        root.addSubview(tint)
+
+        let accentBar = NSView(frame: NSRect(x: 0, y: 0, width: 4, height: panelHeight))
+        accentBar.wantsLayer = true
+        accentBar.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.85).cgColor
+        root.addSubview(accentBar)
+
+        let headerHeight: CGFloat = 34
+        let horizontalPadding: CGFloat = 18
+        let headerY = panelHeight - 16 - headerHeight
+
+        let iconBack = NSView(frame: NSRect(x: horizontalPadding, y: headerY + 5, width: 22, height: 22))
+        iconBack.wantsLayer = true
+        iconBack.layer?.cornerRadius = 11
+        iconBack.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.2).cgColor
+        root.addSubview(iconBack)
+
+        let iconView = NSImageView(frame: NSRect(x: horizontalPadding + 3, y: headerY + 8, width: 16, height: 16))
+        if #available(macOS 11.0, *) {
+            iconView.image = NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: nil)
+            iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+        }
+        iconView.contentTintColor = NSColor.controlAccentColor
+        root.addSubview(iconView)
+
         let titleLabel = NSTextField(labelWithString: config.title)
-        titleLabel.frame = NSRect(x: 14, y: panelHeight - 34, width: width - 54, height: 20)
+        titleLabel.frame = NSRect(x: horizontalPadding + 30, y: headerY + 12, width: width - 118, height: 18)
         titleLabel.font = NSFont.systemFont(ofSize: 14, weight: .semibold)
         titleLabel.textColor = .labelColor
         root.addSubview(titleLabel)
 
+        var meta = "codex-notify"
+        if !config.identifier.isEmpty {
+            meta += "  •  \(shortenedIdentifier(config.identifier))"
+        }
+        let metaLabel = NSTextField(labelWithString: meta)
+        metaLabel.frame = NSRect(x: horizontalPadding + 30, y: headerY - 1, width: width - 118, height: 14)
+        metaLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        metaLabel.textColor = .tertiaryLabelColor
+        root.addSubview(metaLabel)
+
         let closeButton = NSButton(title: "×", target: self, action: #selector(closePopup))
         closeButton.isBordered = false
-        closeButton.frame = NSRect(x: width - 34, y: panelHeight - 36, width: 20, height: 20)
-        closeButton.font = NSFont.systemFont(ofSize: 16, weight: .bold)
-        closeButton.contentTintColor = .secondaryLabelColor
+        closeButton.frame = NSRect(x: width - 34, y: headerY + 8, width: 18, height: 18)
+        closeButton.font = NSFont.systemFont(ofSize: 14, weight: .semibold)
+        closeButton.contentTintColor = .tertiaryLabelColor
         root.addSubview(closeButton)
 
+        let messageY = headerY - 10 - messageHeight
         let messageLabel = NSTextField(wrappingLabelWithString: config.message)
-        messageLabel.frame = NSRect(x: 14, y: 54, width: width - 28, height: messageHeight)
+        messageLabel.frame = NSRect(x: horizontalPadding, y: messageY, width: width - (horizontalPadding * 2), height: messageHeight)
         messageLabel.font = NSFont.systemFont(ofSize: 13, weight: .regular)
         messageLabel.textColor = .secondaryLabelColor
         messageLabel.maximumNumberOfLines = 5
+        messageLabel.alignment = .left
         root.addSubview(messageLabel)
 
-        let stack = NSStackView(frame: NSRect(x: 14, y: 14, width: width - 28, height: 30))
-        stack.orientation = .horizontal
-        stack.alignment = .centerY
-        stack.distribution = .fillEqually
-        stack.spacing = 8
-        for (idx, choice) in config.choices.enumerated() {
-            let button = NSButton(title: choice.label, target: self, action: #selector(choiceClicked(_:)))
-            button.tag = idx
-            button.bezelStyle = .rounded
-            stack.addArrangedSubview(button)
+        let progressHeight: CGFloat = 4
+        let progressY = messageY - 12 - progressHeight
+        let progressTrack = NSView(frame: NSRect(x: horizontalPadding, y: progressY, width: width - (horizontalPadding * 2), height: progressHeight))
+        progressTrack.wantsLayer = true
+        progressTrack.layer?.cornerRadius = progressHeight / 2
+        progressTrack.layer?.masksToBounds = true
+        progressTrack.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.14).cgColor
+
+        let progressFill = NSView(frame: progressTrack.bounds)
+        progressFill.autoresizingMask = [.height]
+        progressFill.wantsLayer = true
+        progressFill.layer?.cornerRadius = progressHeight / 2
+        progressFill.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.95).cgColor
+        progressTrack.addSubview(progressFill)
+        root.addSubview(progressTrack)
+        self.progressFill = progressFill
+        self.progressTrackWidth = progressTrack.bounds.width
+
+        let buttonsY = progressY - 12 - buttonsHeight
+        var nextRowTop = buttonsY + buttonsHeight - rowHeight
+        var globalIndex = 0
+        for row in rows {
+            let rowStack = NSStackView(frame: NSRect(x: horizontalPadding, y: nextRowTop, width: width - (horizontalPadding * 2), height: rowHeight))
+            rowStack.orientation = .horizontal
+            rowStack.alignment = .centerY
+            rowStack.distribution = .fillEqually
+            rowStack.spacing = rowSpacing
+            for choice in row {
+                let intent = choiceIntent(for: choice.label, index: globalIndex, total: config.choices.count)
+                let button = StyledActionButton(
+                    title: choice.label,
+                    intent: intent,
+                    index: globalIndex,
+                    target: self,
+                    action: #selector(choiceClicked(_:))
+                )
+                rowStack.addArrangedSubview(button)
+                globalIndex += 1
+            }
+            root.addSubview(rowStack)
+            nextRowTop -= rowHeight + rowSpacing
         }
-        root.addSubview(stack)
 
         self.panel = panel
+        openedAt = Date()
+        panel.alphaValue = 0
         panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.17
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+            panel.animator().setFrame(finalFrame, display: true)
+        }
 
-        timeoutTimer = Timer.scheduledTimer(timeInterval: TimeInterval(config.timeoutSeconds), target: self, selector: #selector(closePopup), userInfo: nil, repeats: false)
+        timeoutTimer = Timer.scheduledTimer(
+            timeInterval: TimeInterval(config.timeoutSeconds),
+            target: self,
+            selector: #selector(closePopup),
+            userInfo: nil,
+            repeats: false
+        )
+        progressTimer = Timer.scheduledTimer(
+            timeInterval: 0.05,
+            target: self,
+            selector: #selector(updateProgress),
+            userInfo: nil,
+            repeats: true
+        )
     }
 
     private func textHeight(_ text: String, width: CGFloat) -> CGFloat {
-        let attr = NSAttributedString(string: text, attributes: [.font: NSFont.systemFont(ofSize: 13)])
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = 2
+        let attr = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 13, weight: .regular),
+                .paragraphStyle: paragraph
+            ]
+        )
         let rect = attr.boundingRect(with: NSSize(width: width, height: 400), options: [.usesLineFragmentOrigin, .usesFontLeading])
-        return max(20, ceil(rect.height))
+        return max(28, ceil(rect.height))
+    }
+
+    @objc private func updateProgress() {
+        guard let fill = progressFill else {
+            return
+        }
+        let elapsed = Date().timeIntervalSince(openedAt)
+        let ratio = max(0, min(1, 1 - (elapsed / Double(config.timeoutSeconds))))
+        var frame = fill.frame
+        frame.size.width = progressTrackWidth * CGFloat(ratio)
+        fill.frame = frame
     }
 
     @objc private func choiceClicked(_ sender: NSButton) {
@@ -196,11 +526,33 @@ final class PopupController: NSObject {
     }
 
     @objc private func closePopup() {
+        if isClosing {
+            return
+        }
+        isClosing = true
+
         timeoutTimer?.invalidate()
         timeoutTimer = nil
-        panel?.orderOut(nil)
-        panel = nil
-        NSApp.terminate(nil)
+        progressTimer?.invalidate()
+        progressTimer = nil
+
+        guard let panel else {
+            NSApp.terminate(nil)
+            return
+        }
+
+        var fadedFrame = panel.frame
+        fadedFrame.origin.y -= 10
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.12
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+            panel.animator().setFrame(fadedFrame, display: true)
+        }, completionHandler: {
+            panel.orderOut(nil)
+            self.panel = nil
+            NSApp.terminate(nil)
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- approval popup の外観を刷新（カード感・ヘッダー・メタ表示）
- 選択肢ボタンを意味別カラー（Approve/Reject/Open 等）で表示
- 選択肢数に応じて複数行レイアウト対応
- タイムアウト進行バーと入退場アニメーションを追加
- helper に --identifier を取り込み、UI上に短縮表示

## Validation
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./...
- CLANG_MODULE_CACHE_PATH=/tmp/clang-module-cache SWIFT_MODULE_CACHE_PATH=/tmp/swift-module-cache swiftc -O -suppress-warnings internal/swift/approval_action_notifier.swift -o /tmp/approval_action_notifier_test