### PR TITLE
Auto-sync Homebrew tap when main is updated

### DIFF
--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -1,0 +1,58 @@
+name: sync-homebrew-tap
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-homebrew-tap
+  cancel-in-progress: true
+
+jobs:
+  sync-formula:
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v4
+        with:
+          repository: MiUPa/homebrew-codex-notify
+          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          path: homebrew-codex-notify
+
+      - name: Sync Formula file
+        run: |
+          set -euo pipefail
+          cp Formula/codex-notify.rb homebrew-codex-notify/Formula/codex-notify.rb
+
+      - name: Commit and push Formula update
+        working-directory: homebrew-codex-notify
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- Formula/codex-notify.rb; then
+            echo "No Formula changes detected; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/codex-notify.rb
+          git commit -m "Sync Formula from codex-notify@${SOURCE_SHA::7}"
+          git push origin HEAD:main
+
+  missing-token:
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report missing token
+        run: echo "::warning::HOMEBREW_TAP_GITHUB_TOKEN is not set; skipping tap sync."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Added new README demo asset for unified popup UI (`docs/assets/demo-popup-v031.svg`).
 - Added release workflow automation to update `MiUPa/homebrew-codex-notify` Formula after each version tag release.
+- Added a `main` branch sync workflow to automatically reflect Formula updates to `MiUPa/homebrew-codex-notify`.
 - Added Homebrew Formula `post_install` auto-setup (`codex-notify init`) so `brew install` can complete setup without manual init in standard cases.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ brew install codex-notify
 
 The formula installs prebuilt release binaries for macOS (arm64/amd64), so local Go/CLT build steps are not required.
 `brew install codex-notify` also runs `codex-notify init` via Formula `post_install` to configure the hook automatically.
+When `main` is updated, this repository's Formula is automatically synced to `MiUPa/homebrew-codex-notify`.
 
 `Formula/codex-notify.rb` in this repository is the source template for your tap repository (`MiUPa/homebrew-codex-notify`).
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,6 +20,7 @@ This triggers `.github/workflows/release.yml` and creates a GitHub Release with:
 ## 3. Update Homebrew tap
 
 `release.yml` automatically updates `MiUPa/homebrew-codex-notify` after the GitHub Release is published.
+Additionally, `sync-homebrew-tap.yml` keeps the tap Formula in sync whenever `main` is updated.
 Prerequisite: repository secret `HOMEBREW_TAP_GITHUB_TOKEN` must be configured with push access to the tap repository.
 
 Manual fallback (if automation fails):


### PR DESCRIPTION
Summary:\n- add sync-homebrew-tap workflow to sync Formula to MiUPa/homebrew-codex-notify on every push to main\n- keep workflow_dispatch for manual trigger\n- show warning when HOMEBREW_TAP_GITHUB_TOKEN is missing\n- update README, RELEASING, and CHANGELOG